### PR TITLE
TypeParser: Support defaulted types

### DIFF
--- a/src/com/redhat/ceylon/model/loader/TypeLexer.java
+++ b/src/com/redhat/ceylon/model/loader/TypeLexer.java
@@ -23,6 +23,7 @@ public class TypeLexer {
     public final static int PLUS = STAR + 1;// +
     public final static int THIN_ARROW = PLUS + 1;// ->
     public final static int QN = THIN_ARROW + 1;// ?
+    public final static int EQ = QN + 1;// =
 
     // type string to parse
     char[] type;
@@ -76,6 +77,7 @@ public class TypeLexer {
         case '*': token = STAR; break;
         case '+': token = PLUS; break;
         case '?': token = QN; break;
+        case '=': token = EQ; break;
         case '-':
             if((index + 1) < type.length
                     && type[index + 1] == '>')
@@ -129,6 +131,7 @@ public class TypeLexer {
             case '*':
             case '+':
             case '-':
+            case '=':
             case ' ':// note: break on ws
                 break FOR;
             }
@@ -189,6 +192,7 @@ public class TypeLexer {
         case PLUS: return "PLUS";
         case THIN_ARROW: return "THIN_ARROW";
         case QN: return "QN";
+        case EQ: return "EQ";
         }
         // cannot happen
         throw new TypeParserException("Unhandled token: "+token);


### PR DESCRIPTION
The TypeLexer can now lex `=` tokens as well (type `EQ`), and the TypeParser can parse type lists with defaulted types, which can appear in callable types (`Integer(String,Integer=)`) and tuple types (`[String,String=]`).

To support this, TypeList.asTuple was completely rewritten; it is now recursive instead of iterative.

To create union and intersection types, we now use the functions `unionType` and `intersectionType` instead of `union` and `intersection` respectively. The difference between them is that the -Type versions correctly simplify the type (remove duplicates, union with Nothing, etc.). This was necessary for constructing the tuples in asTuple() since they would otherwise contain an unnecessary union with Nothing in every first type parameter to Tuple (Nothing being the element type of Empty), and also makes sense elsewhere. This shouldn't change anything in real compiled code, since the types there are already simplified, but it does break some of the tests in ceylon-compiler, which have to be updated to take this into account.

This fixes #3.

**NOTE:** I don’t think this is ready for merge as it is now, since it produces some additional test failures in ceylon-compiler that I haven’t been able to fix (see ceylon/ceylon-compiler#2227 for details). This is just the point where I have to give up and let someone else (@tombentley?) take over, who can hopefully use this work as a starting point. (I’m fairly confident that the algorithm in `TypeList.asTuple()` is correct, but I must be doing some part of the type construction wrong.)
