### PR TITLE
Temporary fix to make it compile

### DIFF
--- a/src/com/redhat/ceylon/model/loader/NamingBase.java
+++ b/src/com/redhat/ceylon/model/loader/NamingBase.java
@@ -56,6 +56,7 @@ public class NamingBase {
         $sb$,
         $spreadVarargs$,
         $TypeDescriptor$,
+        $apply$, apply,
         
         $serialize$,
         deconstructor,


### PR DESCRIPTION
This seems to be required for ceylon/ceylon-compiler@d580516. I think @tombentley forgot to push something in this repository, so I hope he’ll give us the right fix [on tuesday](https://gitter.im/ceylon/user?at=55e079fe33e556c746e36156) :)

With this, `ceylon-dist` builds, and `ant test` in `ceylon-compiler` gives me 1 error and 26 failures out of 2947 tests run. I can also cleanly build `ceylon.ast`, and all tests pass there. So I think this is clearly an improvement over the current state.
